### PR TITLE
add option to update archlinux-keyring

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,17 @@ Here's what this action can do:
 
 Following inputs can be used as `step.with` keys
 
-| Name         | Type    | Default            | Required | Description                                                                      |
-| ------------ | ------- | ------------------ | -------- | -------------------------------------------------------------------------------- |
-| `path`       | String  |                    | `false`  | Path where PKGBUILD is located. This path always located under $GITHUB_WORKSPACE |
-| `pkgver`     | String  |                    | `false`  | Update `pkgver` on your PKGBUILD                                                 |
-| `pkgrel`     | Integer |                    | `false`  | Update `pkgrel` on your PKGBUILD                                                 |
-| `updpkgsums` | Boolean | `false`            | `false`  | Update checksums on your PKGBUILD                                                |
-| `srcinfo`    | Boolean | `false`            | `false`  | Generate new .SRCINFO                                                            |
-| `namcap`     | Boolean | `true`             | `false`  | Validate PKGBUILD                                                                |
-| `flags`      | String  | `-cfs --noconfirm` | `false`  | Flags after `makepkg` command. Leave this empty will disable this command.       |
-| `aur`        | Boolean | `false`            | `false`  | Resolve dependencies using paru                                                  |
+| Name                       | Type    | Default            | Required | Description                                                                      |
+| -------------------------- | ------- | ------------------ | -------- | -------------------------------------------------------------------------------- |
+| `path`                     | String  |                    | `false`  | Path where PKGBUILD is located. This path always located under $GITHUB_WORKSPACE |
+| `pkgver`                   | String  |                    | `false`  | Update `pkgver` on your PKGBUILD                                                 |
+| `pkgrel`                   | Integer |                    | `false`  | Update `pkgrel` on your PKGBUILD                                                 |
+| `updpkgsums`               | Boolean | `false`            | `false`  | Update checksums on your PKGBUILD                                                |
+| `srcinfo`                  | Boolean | `false`            | `false`  | Generate new .SRCINFO                                                            |
+| `namcap`                   | Boolean | `true`             | `false`  | Validate PKGBUILD                                                                |
+| `flags`                    | String  | `-cfs --noconfirm` | `false`  | Flags after `makepkg` command. Leave this empty will disable this command.       |
+| `aur`                      | Boolean | `false`            | `false`  | Resolve dependencies using paru                                                  |
+| `update_archlinux_keyring` | Boolean | `true`             | `false`  | Update the archlinux keyring                                                     |
 
 ### Examples
 

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,10 @@ inputs:
     description: 'Resolve dependencies using paru'
     default: 'false'
     required: false
+  update_archlinux_keyring:
+    description: 'Update archlinux-keyring'
+    default: 'true'
+    required: false
 
 runs:
   using: 'docker'
@@ -52,3 +56,4 @@ runs:
     - ${{ inputs.flags }}
     - ${{ inputs.namcap }}
     - ${{ inputs.aur }}
+    - ${{ inputs.update_archlinux_keyring }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,13 @@ cp -rfv "$GITHUB_WORKSPACE"/.git ./
 cp -fv "$WORKPATH"/PKGBUILD ./
 echo "::endgroup::"
 
+# Update archlinux-keyring
+if [[ $INPUT_ARCHLINUX_KEYRING == true ]]; then
+    echo "::group::Updating archlinux-keyring"
+    pacman -S archlinux-keyring
+    echo "::endgroup::"
+fi
+
 # Update pkgver
 if [[ -n $INPUT_PKGVER ]]; then
     echo "::group::Updating pkgver on PKGBUILD"


### PR DESCRIPTION
This PR adds an input option to update the archlinux-keyring.

Fixes #26 

I have tested this change.

Before change, workflow failing: https://github.com/SunshineStream/Sunshine/runs/7520194931?check_suite_focus=true#step:7:425

After change, workflow succeeds: https://github.com/SunshineStream/Sunshine/runs/7571321585?check_suite_focus=true#step:7:1