### PR TITLE
fix `update_archlinux_keyring` input

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,9 +14,9 @@ cp -fv "$WORKPATH"/PKGBUILD ./
 echo "::endgroup::"
 
 # Update archlinux-keyring
-if [[ $INPUT_ARCHLINUX_KEYRING == true ]]; then
+if [[ $INPUT_UPDATE_ARCHLINUX_KEYRING == true ]]; then
     echo "::group::Updating archlinux-keyring"
-    pacman -S archlinux-keyring
+    sudo pacman -S --noconfirm archlinux-keyring
     echo "::endgroup::"
 fi
 


### PR DESCRIPTION
Fixes the input variable name of the `update_archlinux_keyring` input, in the `entrypoint.sh`. Additionally, fixes the command used to update the keyring.

While investigating #32, I discovered that the this section of the script was not running.

I have done my best to test this by replicating your repo (here: https://github.com/LizardByte/archlinux-package-action), including the image published to ghcr. It's a bit difficult to test another branch. If possible, I'd suggest that the action wouldn't rely on a published docker image. Maybe it could just build the image when the action runs? Anyway, I've tested the image in my workflow, here are the results: https://github.com/LizardByte/Sunshine/actions/runs/3606596462/jobs/6078056553#step:7:61

I believe this fixes #32 